### PR TITLE
Fixed incorrect name for the UserManagement.API

### DIFF
--- a/Cypherly.UserManagement.API/Program.cs
+++ b/Cypherly.UserManagement.API/Program.cs
@@ -123,7 +123,7 @@ builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new()
     {
-        Title = "Cypherly.Authentication.API",
+        Title = "Cypherly.UserManagement.API",
         Version = "v1"
     });
 


### PR DESCRIPTION
Boot up cypherly and confirm the name has changed on the swagger page.